### PR TITLE
k8s handler uses client data from solar resources

### DIFF
--- a/composer_files/mariadb.yaml
+++ b/composer_files/mariadb.yaml
@@ -1,6 +1,7 @@
 resources:
   - id: mariadb_deployment
     from: k8s-modules/MariadbDeployment
+    location: k8s_api
     input:
       dns_name: mariadb-deployment
       labels:
@@ -10,6 +11,7 @@ resources:
       db_password: mariadb
 
   - id: mariadb_service
+    location: k8s_api
     from: k8s-modules/MariadbService
     input:
       dns_name: mariadb-service

--- a/composer_files/transport.yaml
+++ b/composer_files/transport.yaml
@@ -1,6 +1,9 @@
 resources:
   - id: k8s_job_transport
     from: k8s-modules/transport_k8sjob
+    input:
+      host: kube-node-master::ip
+      port: kubelet-master::master_port
 
   - id: k8s_api
     from: resources/transports
@@ -8,3 +11,5 @@ resources:
       transports:
         - name: k8s_job_transport::name
           user: k8s_job_transport::user
+          host: k8s_job_transport::host
+          port: k8s_job_transport::port

--- a/k8s-modules/transports/1.0.0/meta.yaml
+++ b/k8s-modules/transports/1.0.0/meta.yaml
@@ -1,0 +1,12 @@
+input:
+  transports:
+    schema: [{}]
+    value: []
+  transports_id:
+    schema: str!
+    value: $uuid
+    reverse: True
+  location_id:
+    schema: str
+    value:
+    reverse: True

--- a/solar_k8s/k8s_handler.py
+++ b/solar_k8s/k8s_handler.py
@@ -17,17 +17,14 @@ import shutil
 import tempfile
 import time
 
+import pykube.objects
+import yaml
+
 from solar.core.handlers.base import TempFileHandler
 from solar.core.log import log
 from solar import errors
-
-from pykube.config import KubeConfig
-from pykube.http import HTTPClient
-import pykube.objects
-
-import yaml
-
 from solar_k8s import jsondiff
+from solar_k8s.kube_utils import get_kube_api
 
 
 class K8S(TempFileHandler):
@@ -36,7 +33,7 @@ class K8S(TempFileHandler):
         super(K8S, self).__init__(resources, handlers)
 
     def action(self, resource, action_name):
-        api = HTTPClient(KubeConfig.from_file("~/.kube/config"))
+        api = get_kube_api(resource.transports()[0])
         log.debug('Executing %s %s',
                   action_name, resource.name)
 

--- a/solar_k8s/k8s_handler.py
+++ b/solar_k8s/k8s_handler.py
@@ -18,11 +18,11 @@ import tempfile
 import time
 
 import pykube.objects
-import yaml
-
 from solar.core.handlers.base import TempFileHandler
 from solar.core.log import log
 from solar import errors
+import yaml
+
 from solar_k8s import jsondiff
 from solar_k8s.kube_utils import get_kube_api
 

--- a/solar_k8s/kube_utils.py
+++ b/solar_k8s/kube_utils.py
@@ -1,0 +1,51 @@
+#    Copyright 2016 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from pykube.config import KubeConfig
+from pykube.http import HTTPClient
+
+
+def get_kube_api(transport):
+    config = {
+        "apiVersion": "v1",
+        "clusters": [
+            {
+                "cluster":{
+                    "server": "http://{0}:{1}".format(transport['host'],
+                                                      transport['port'])
+                },
+                "name": "opensnek"
+            }
+        ],
+        "contexts": [
+            {
+                "context": {
+                    "cluster": "opensnek",
+                    "namespace": "",
+                    "user": "user"
+                },
+                "name": "osctx"
+            }
+        ],
+        "users": [
+            {
+                "user": {},
+                "name": "user"
+            }
+        ],
+        "current-context": "osctx",
+        "kind": "Config",
+        "preferences": {}
+    }
+
+    return HTTPClient(KubeConfig(config))


### PR DESCRIPTION
~/.kube/config file is not longer used there.
